### PR TITLE
Headers to get_token and some other endpoints

### DIFF
--- a/requests_oauth2/oauth2.py
+++ b/requests_oauth2/oauth2.py
@@ -32,14 +32,19 @@ class OAuth2(object):
         oauth_params.update(kwargs)
         return "%s%s?%s" % (self.site, quote(self.authorization_url), urlencode(oauth_params))
 
-    def get_token(self, code, **kwargs):
+
+    def get_token(self, code, headers=None, **kwargs):
         """
         Requests an access token
         """
         url = "%s%s" % (self.site, quote(self.token_url))
         data = {'redirect_uri': self.redirect_uri, 'client_id': self.client_id, 'client_secret': self.client_secret, 'code': code}
         data.update(kwargs)
-        response = requests.post(url, data=data)
+
+        if headers:
+            response = requests.post(url, data=data, headers=headers)
+        else:
+            response = requests.post(url, data=data)
 
         if isinstance(response.content, basestring):
             try:

--- a/requests_oauth2/oauth2.py
+++ b/requests_oauth2/oauth2.py
@@ -10,8 +10,10 @@ except ImportError:
 class OAuth2(object):
     authorization_url = '/oauth/authorize'
     token_url = '/oauth/token'
+    revoke_url = '/oauth2/revoke'
 
-    def __init__(self, client_id, client_secret, site, redirect_uri, authorization_url=None, token_url=None):
+    def __init__(self, client_id, client_secret, site, redirect_uri,
+        authorization_url=None, token_url=None, revoke_url=None):
         """
         Initializes the hook with OAuth2 parameters
         """
@@ -23,24 +25,13 @@ class OAuth2(object):
             self.authorization_url = authorization_url
         if token_url is not None:
             self.token_url = token_url
+        if revoke_url is not None:
+            self.revoke_url = revoke_url
 
-    def authorize_url(self, scope='', **kwargs):
+    def _make_request(self, url, data, headers=None):
         """
-        Returns the url to redirect the user to for user consent
+        Make a request to an OAuth2 endpoint
         """
-        oauth_params = {'redirect_uri': self.redirect_uri, 'client_id': self.client_id, 'scope': scope}
-        oauth_params.update(kwargs)
-        return "%s%s?%s" % (self.site, quote(self.authorization_url), urlencode(oauth_params))
-
-
-    def get_token(self, code, headers=None, **kwargs):
-        """
-        Requests an access token
-        """
-        url = "%s%s" % (self.site, quote(self.token_url))
-        data = {'redirect_uri': self.redirect_uri, 'client_id': self.client_id, 'client_secret': self.client_secret, 'code': code}
-        data.update(kwargs)
-
         if headers:
             response = requests.post(url, data=data, headers=headers)
         else:
@@ -55,3 +46,41 @@ class OAuth2(object):
             content = response.content
 
         return content
+
+    def authorize_url(self, scope='', **kwargs):
+        """
+        Returns the url to redirect the user to for user consent
+        """
+        oauth_params = {'redirect_uri': self.redirect_uri, 'client_id': self.client_id, 'scope': scope}
+        oauth_params.update(kwargs)
+        return "%s%s?%s" % (self.site, quote(self.authorization_url), urlencode(oauth_params))
+
+    def get_token(self, code, headers=None, **kwargs):
+        """
+        Requests an access token
+        """
+        url = "%s%s" % (self.site, quote(self.token_url))
+        data = {'redirect_uri': self.redirect_uri, 'client_id': self.client_id, 'client_secret': self.client_secret, 'code': code}
+        data.update(kwargs)
+
+        return self._make_request(url, data, headers)
+
+    def refresh_token(self, headers=None, **kwargs):
+        """
+        Request a refreshed token
+        """
+        url = "%s%s" % (self.site, quote(self.token_url))
+        data = {'client_id': self.client_id, 'client_secret': self.client_secret}
+        data.update(kwargs)
+
+        return self._make_request(url, data, headers)
+
+    def revoke_token(self, token, headers=None, **kwargs):
+        """
+        Revoke an access token
+        """
+        url = "%s%s" % (self.site, quote(self.revoke_url))
+        data = {'token': token}
+        data.update(kwargs)
+
+        return self._make_request(url, data, headers)


### PR DESCRIPTION
In some cases, like Salesforce, Content-Type is required to be set to get the token. See thread here:

http://boards.developerforce.com/t5/General-Development/unsupported-grant-type-for-OAuth-2-0-Web-Server/td-p/216063
